### PR TITLE
Detect mention spam

### DIFF
--- a/index.js
+++ b/index.js
@@ -377,7 +377,7 @@ bot.on('message', message => {
                     [/.*([^.\s])\1{6,}.*/gi, 1, "Repeated Character Filter"], //repeated characters
                     [/.*b+a+z+a{4,}.*/gi, 1, "Bazza Filter"], //Bazza filter
                     [emojiRegex(), 10, "Emoji Filter"], //emojis
-                    [/.*<@{5,}.*/gi, 1, "Mention Spam Filter"] //mass mentioning
+                    [/.*@{5,}.*/gi, 1, "Mention Spam Filter"] //mass mentioning
                 ]) {
                     var occurred = message.content.match(rule[0]);
                     if (!occurred) continue;

--- a/index.js
+++ b/index.js
@@ -376,7 +376,8 @@ bot.on('message', message => {
                 for (var rule of [
                     [/.*([^.\s])\1{6,}.*/gi, 1, "Repeated Character Filter"], //repeated characters
                     [/.*b+a+z+a{4,}.*/gi, 1, "Bazza Filter"], //Bazza filter
-                    [emojiRegex(), 10, "Emoji Filter"] //emojis
+                    [emojiRegex(), 10, "Emoji Filter"], //emojis
+                    [/.*<@{5,}.*/gi, 1, "Mention Spam Filter"] //mass mentioning
                 ]) {
                     var occurred = message.content.match(rule[0]);
                     if (!occurred) continue;
@@ -505,4 +506,3 @@ schedule.scheduleJob('*/10 * * * * *', function () {
 
 //Login to discord
 bot.login(config.botToken);
-


### PR DESCRIPTION
Larger servers are likely to be targeted by so-called raids, which means users joining the server and mass mentioning people as long as they can. This leads to obscene mention amounts when the individual returns to the server and you can't combat manual mention spamming via Discord either.

The regex filter I built checks if more than 5 `@` characters are found in a single message. The amount can be adjusted, but generally you don't need to mention more than that without a role mention. It also doesn't matter which way the bot receives the mention, as the raw of `@LWTechGaming` is `<@152664793587777537>` and it still contains the `@`.

The system is also not triggered by channels or custom emotes. The raw of `#test` in my testing server equals `<#256129842406227968>` and a custom emote called `dippDab` has a raw of `<:dippDab:252166729885548547>`.

If you notice issues with my changes, feel free to tell me and I'll rectify them.