### PR TITLE
Add role ID based whitelist and lobby link filtering, improve checks

### DIFF
--- a/app/ChatFilters.js
+++ b/app/ChatFilters.js
@@ -202,4 +202,18 @@ filters.racismFilter = {
     }
 };
 
+filters.linkFilter = {
+    displayName: "Lobby Link Filter",
+    check: message => {
+      let channels = ["249323706285948928","252543317844295680"];
+      let filters = [/.*http:\/\/.*/gi, /.*www.*/gi];
+      return channels.indexOf(message.channel.id) > -1 && filters.filter(regex => message.content.match(regex)).length > 0;
+    },
+    action: message => {
+        message.delete();
+        message.author.sendMessage("Your message was removed: Posting links in the lobby channels is prohibited.");
+        // Do not issue infraction for posting links, just keep the chat clean
+    }
+};
+
 module.exports.filters = filters;

--- a/app/Events.js
+++ b/app/Events.js
@@ -28,13 +28,25 @@ DiscordUtils.client.on('guildMemberAdd', guildMember => {
 DiscordUtils.client.on('message', message => {
         //Disable PM
         if (!message.guild) return;
+        //Prevent triggering of self
+        if (!message.author.bot) return;
         //Command detection
         if (message.content.startsWith("!")) {
             processCommand(message);
             return;
         }
-        //Pull through chatfilters if user is applicable to punishment
-        if (!message.author.bot && config.notAffected.indexOf(message.author.username) == -1) ChatFilters.process(message);
+        //Check if user is on role whitelist
+        let member = message.guild.members.get(message.author.id);
+        let whitelist = false;
+        for (let role of member.roles) {
+            if (role[1].id == config.whitelistedRoles) {
+                whitelist = true;
+                break;
+            }
+        }
+        if (!whitelist) {
+            ChatFilters.process(message);
+        }
     }
 );
 

--- a/app/Events.js
+++ b/app/Events.js
@@ -26,10 +26,10 @@ DiscordUtils.client.on('guildMemberAdd', guildMember => {
 
 //Handle message receive event
 DiscordUtils.client.on('message', message => {
+        //Prevent bot from using itself
+        if (!message.author.bot) return;
         //Disable PM
         if (!message.guild) return;
-        //Prevent triggering of self
-        if (!message.author.bot) return;
         //Command detection
         if (message.content.startsWith("!")) {
             processCommand(message);


### PR DESCRIPTION
This removes the `config.notAffected` based check for bypassing chat filters and replaces it with a role whitelist (`config.whitelistedRoles`). Users who possess a role specified in the configuration file will bypass chat filters entirely.

I also rewrote the old filter ignore check. Instead of checking for usernames specified `config.notAffected` it now checks for if the user possesses a role ID specified in `config.whitelistedRoles`. In addition, I moved the self trigger prevention to a separate check that is issued before anything else for better efficiency.

EDIT: Added the link filter I forgot to introduce yesterday.