### PR TITLE
Urgent fix for scam links

### DIFF
--- a/app/ChatFilters.js
+++ b/app/ChatFilters.js
@@ -222,6 +222,29 @@ filters.linkFilter = {
     }
 };
 
+filters.linkFilter = {
+    displayName: "Scam Link Filter",
+    check: message => {
+        return new Promise(resolve => {
+                let rules = [
+                  /.*giftsofsteam.*/gi //Giftsofsteam scam
+                ];
+                resolve(rules.filter(rule => message.content.match(rule)).length > 0)
+            }
+        );
+    },
+    action: message => {
+        message.delete();
+        message.author.sendMessage("Your message was removed: Posting scam links is prohibited.\nIf you did this unknowingly, your login details to whatever site (Steam etc. ) may be compromised. Change them immediately!");
+        let infraction = new Infraction(message.author.id, moment().unix(), false, "WARN", null, {
+            displayName: "Scam Link Filter",
+            triggerMessage: message.content
+        });
+        infraction.save();
+        Logging.infractionLog(infraction);
+    }
+};
+
 filters.floodFilter = {
     displayName: "Flood-Spam Filter",
     check: message => {


### PR DESCRIPTION
Some scam links like `giftsofsteam` are circumventing the link filter, as reported by LightRod earlier.

![Scam report](http://i.imgur.com/ujN5KFk.png)

This is a fix for harmful links like this. The message will be deleted and the user will be informed that their login details might be compromised.

Side note, my health is kinda flaundering so if there's bugs in this you'll have to correct them. It's something anyway that I had time to write 😄 