### PR TITLE
Add filter for offensive wording, add scam link to filter

### DIFF
--- a/app/ChatFilters.js
+++ b/app/ChatFilters.js
@@ -200,7 +200,7 @@ filters.offensiveFilter = {
     displayName: "Offensive Behavior Filter",
     check: message => {
         return new Promise(resolve => {
-            let rules = [
+            let rules = [   //Potentially expand this later
                 /.*\bk+y+s\b.*/gi //kys
             ];
             resolve(rules.filter(rule => message.content.match(rule)).length > 0)

--- a/app/ChatFilters.js
+++ b/app/ChatFilters.js
@@ -196,6 +196,35 @@ filters.racismFilter = {
     }
 };
 
+filters.offensiveFilter = {
+    displayName: "Offensive Behavior Filter",
+    check: message => {
+        return new Promise(resolve => {
+            let rules = [
+                /.*\bk+y+s\b.*/gi //kys
+            ];
+            resolve(rules.filter(rule => message.content.match(rule)).length > 0)
+        });
+    },
+    action: message => {
+        message.delete();
+        message.author.sendMessage("Your message was removed: Offensive behavior towards other members is not permitted.");
+
+        //Punish
+        UserUtils.increaseNotoriety(message.author.id)
+            .then((actionData) => {
+                let infraction = new Infraction(message.author.id, moment().unix(), true, actionData.type, actionData.meta, {
+                    displayName: "Offensive Behavior Filter",
+                    triggerMessage: message.content
+                });
+                infraction.save();
+                Logging.infractionLog(infraction);
+            }).catch(err => {
+            Logging.error("OFFENSIVE_FILTER_ACTION", err);
+        });
+    }
+};
+
 filters.linkFilter = {
     displayName: "Lobby Link Filter",
     check: message => {
@@ -231,6 +260,7 @@ filters.scamLinkFilter = {
         return new Promise(resolve => {
                 let rules = [
                     /.*https{0,1}:\/\/(www\.|)giftsofsteam\.com(\/|).*/gi //Giftsofsteam scam
+                    /.*https{0,1}:\/\/riotpoints\.give-aways\.net.*/gi //Riot Points scam
                 ];
                 resolve(rules.filter(rule => message.content.match(rule)).length > 0)
             }


### PR DESCRIPTION
First thing added in this is a separate filter for offensive wording that can be expanded upon later as per request from GamerNurse.

![Suggestion](http://i.imgur.com/nQ9KMTU.png)

Also added a new scam link to the scam filtering as per warning from LightRod.

![New scam](http://i.imgur.com/Kdk69SJ.png)

Also I have no idea where those merge commits popped in from. The heck?