### PR TITLE
Implement early version of ban logging

### DIFF
--- a/app/Events.js
+++ b/app/Events.js
@@ -44,6 +44,18 @@ DiscordUtils.client.on('message', message => {
     }
 );
 
+//Log ban event
+//TODO: Write proper ban and reason system with command
+DiscordUtils.client.on('guildBanAdd', (guild, user) => {
+  Logging.mod(Logging.format("BAN", "issued to _" + user.username + " (" + user.id + ")_"));
+})
+
+//Log unban event
+DiscordUtils.client.on('guildBanRemove', (guild, user) => {
+  Logging.mod(Logging.format("UNBAN", "issued to _" + user.username + " (" + user.id + ")_"));
+})
+
+
 let processCommand = message => {
     //TODO: Implement command framework
     // let split = message.content.trim().split(/\s+/);


### PR DESCRIPTION
This will prevent bans from going unnoticed. Ban and unban events are logged. In the future, the plan is to allow moderators to use a command to ban users and submit a reason at the same time, have it all applied into a log. I'm too tired to work on that now as it's past midnight (No pun intended) but here's this anyway.