### PR TITLE
Message improvements

### DIFF
--- a/app/ChatFilters.js
+++ b/app/ChatFilters.js
@@ -37,7 +37,7 @@ filters.mentionFilter = {
     },
     action: (message) => {
         message.delete();
-        message.author.sendMessage("Your message was removed: It is not permitted to mention members from the 'Grandmaster Gang' directly.");
+        message.author.sendMessage("Your message was removed: It is not permitted to mention members of the Grandmaster Gang directly."); //Grammar fix, not from but of
 
         //Punish
         UserUtils.increaseNotoriety(message.author.id).then(actionData => {
@@ -62,7 +62,7 @@ filters.repeatedCharFilter = {
     },
     action: message => {
         message.delete();
-        message.author.sendMessage("Your message was removed: Spamming messages or posting messages with spam-like content is not permitted.");
+        message.author.sendMessage("Your message was removed: Posting messages with spam-like content is not permitted.");
         let infraction = new Infraction(message.author.id, moment().unix(), false, "WARN", null, {
             displayName: "Repeated Character Filter",
             triggerMessage: message.content
@@ -81,7 +81,7 @@ filters.bazzaFilter = {
     },
     action: message => {
         message.delete();
-        message.author.sendMessage("Your message was removed: Spamming messages or posting messages with spam-like content is not permitted.");
+        message.author.sendMessage("Your message was removed: Posting messages with spam-like content is not permitted.");
 
         //Punish
         let infraction = new Infraction(message.author.id, moment().unix(), false, "WARN", null, {
@@ -103,7 +103,7 @@ filters.emojiSpamFilter = {
     },
     action: message => {
         message.delete();
-        message.author.sendMessage("Your message was removed: Spamming messages or posting messages with spam-like content is not permitted.");
+        message.author.sendMessage("Your message was removed: Posting messages with spam-like content is not permitted.");
 
         //Punish
         let infraction = new Infraction(message.author.id, moment().unix(), false, "WARN", null, {
@@ -124,7 +124,7 @@ filters.bulkMentionFilter = {
     },
     action: message => {
         message.delete();
-        message.author.sendMessage("Your message was removed: Spamming messages or posting messages with spam-like content is not permitted.");
+        message.author.sendMessage("Your message was removed: Mass mentioning people is not permitted.");
 
         //Punish
         UserUtils.increaseNotoriety(message.author.id).then(actionData => {
@@ -208,7 +208,7 @@ filters.offensiveFilter = {
     },
     action: message => {
         message.delete();
-        message.author.sendMessage("Your message was removed: Offensive behavior towards other members is not permitted.");
+        message.author.sendMessage("Your message was removed: Offensive behavior towards other members is not permitted here.");
 
         //Punish
         UserUtils.increaseNotoriety(message.author.id)
@@ -303,7 +303,7 @@ filters.floodFilter = {
             }));
     },
     action: message => {
-        message.author.sendMessage("Spamming messages or posting messages with spam-like content is not permitted.");
+        message.author.sendMessage("Your messages were removed: Rapid message spam is not permitted.");
 
         //Reset floodcount & remove messages
         let key = message.author.id + ":floodcount";

--- a/app/Events.js
+++ b/app/Events.js
@@ -48,12 +48,12 @@ DiscordUtils.client.on('message', message => {
 //TODO: Write proper ban and reason system with command
 //TODO: Save these as infractions
 DiscordUtils.client.on('guildBanAdd', (guild, user) => {
-  Logging.mod(Logging.format("BAN", "issued to _" + user.username + " (" + user.id + ")_"));
+  Logging.mod(Logging.format("MANUAL BAN", "issued to **" + user.username + "** (**" + user.id + "**)"));
 });
 
 //Log unban event
 DiscordUtils.client.on('guildBanRemove', (guild, user) => {
-  Logging.mod(Logging.format("UNBAN", "issued to _" + user.username + " (" + user.id + ")_"));
+  Logging.mod(Logging.format("MANUAL UNBAN", "issued to **" + user.username + "** (**" + user.id + "**)"));
 });
 
 
@@ -86,7 +86,7 @@ let combatMuteEvasion = guildMember => {
             DiscordUtils.getRole(guildMember.guild, "Muted").then(role => guildMember.addRole(role)).catch(err => Logging.error("MUTE_EVASION_REAPPLICATION", err));
 
             //Leave log
-            Logging.mod(Logging.format("MUTE EVASION DETECTED", "By user _" + guildMember.user.username + " (" + guildMember.user.id + ")_"));
+            Logging.mod(Logging.format("MUTE EVASION DETECTED", "By user **" + guildMember.user.username + "** (**" + guildMember.user.id + ")**"));
         }
     });
 };

--- a/app/Logging.js
+++ b/app/Logging.js
@@ -35,11 +35,11 @@ module.exports.infractionLog = infraction => {
     let msg = "";
     switch (infraction.action.type) {
         case "MUTE":
-            msg = "_(" + ((infraction.action.meta == Number.MAX_SAFE_INTEGER) ? "Permanent" : TimeUtils.readableInterval(infraction.action.meta)) + ")_ ";
+            msg = "(**" + ((infraction.action.meta == Number.MAX_SAFE_INTEGER) ? "Permanent" : TimeUtils.readableInterval(infraction.action.meta)) + "**) ";
             break;
     }
     DiscordUtils.client.fetchUser(infraction.userid).then(user => {
-        msg += "User _" + user.username + " (" + infraction.userid + ")_ has received an infraction.";
+        msg += "User **" + user.username + "** (**" + infraction.userid + "**) has received an infraction.";
         if (infraction.filter)
             msg += "\nFilter: " + infraction.filter.displayName;
         //TODO: Add link url to infraction information here


### PR DESCRIPTION
The aim of this is to improve message clarity in logging and infraction messages issued to users. Most notably, the modlog names and IDs will use bold formatting only for important bits (Event, user, ID) instead of more hard-to-percept italic formatting.

Another improvement is that a difference between spamming and posting messages with spam-like content is now being made clear. The flood-spam filter will now display a more helpful message to the user saying that flooding the chat is forbidden. Other filters that react to spam-esque content within a message distinct that the content was spammy. There is still no distinction upon what they did to trigger the filter or how to get around it, just a clarification what they did wrong so they don't overstep bounds again.

Also a minor grammar fix, `members of the Grandmaster Gang` instead of `members from`. When a ban event is detected, the bot will now specify that the ban was manual and not performed by it to lessen confusion. The mute and ban commands are still in the works, expect those sometime in the future.